### PR TITLE
Add edit_file tool for diff-based file editing

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -65,17 +65,21 @@ pub fn get_settings() -> Settings {
 Current Objective: {user_input}
 
 You have access to a set of tools to interact with the system:
-- `read_file`: Read file contents.
-- `write_file`: Create or overwrite files.
+- `read_file`: Read file contents with line numbers. Use offset/limit for large files, search for finding specific text.
+- `edit_file`: Edit existing files with surgical precision. Two modes:
+  1) Search-and-replace: provide old_string + new_string to find and replace exact text.
+  2) Line-range: provide start_line + end_line + new_string to replace specific lines (line numbers from read_file).
+- `write_file`: Create new files or fully overwrite existing ones. Prefer edit_file for modifying existing files.
 - `search_files`: Find files by name/pattern.
 - `run_shell_command`: Execute shell commands (requires user approval).
 - `web_search`: Search the internet.
 
 OPERATIONAL GUIDELINES:
 1. **Explore First:** Use `search_files` and `read_file` to understand the codebase before making changes.
-2. **Verify:** After writing a file, verify it works or compiles if possible.
-3. **Iterate:** Break complex tasks into smaller steps.
-4. **Communication:** If you need user input, simply ask a question in your response. If you are done, state that the task is complete.
+2. **Edit Surgically:** Always use `read_file` first, then `edit_file` for targeted changes. Only use `write_file` for new files or complete rewrites.
+3. **Verify:** After editing a file, verify it works or compiles if possible.
+4. **Iterate:** Break complex tasks into smaller steps.
+5. **Communication:** If you need user input, simply ask a question in your response. If you are done, state that the task is complete.
 ".to_string(),
     };
 


### PR DESCRIPTION
Instead of requiring full file rewrites via write_file, the agent can
now make surgical edits with two modes:
- Search-and-replace: find exact text and replace it (with replace_all option)
- Line-range: replace specific line ranges using line numbers from read_file

Also updates read_file description to highlight line number output and
updates the agent prompt to guide the model toward edit_file over write_file.

https://claude.ai/code/session_01WvRvcBgrMHNziJ2SnTNmvy